### PR TITLE
Extract keys from WCS request

### DIFF
--- a/django_services/cache/urls.py
+++ b/django_services/cache/urls.py
@@ -5,4 +5,5 @@ from . import views
 urlpatterns = [
     url(r'^$', views.index, name="index"),
     url(r'^cache/(.*)$', views.get_resource, name="cache"),
+    url(r'^wcs/', views.wcs, name="wcs")
 ]

--- a/django_services/cache/views.py
+++ b/django_services/cache/views.py
@@ -40,3 +40,27 @@ def get_resource(request, filename):
     else:
         response = response_from_file(full_path)
     return response
+
+
+def wcs(request):
+    """Entry point for a WCS request."""
+    service = request.GET["service"]
+    version = request.GET["version"]
+    req_type = request.GET["request"]
+    id_list = request.GET.getlist("id")
+    subsets = {}
+    for x in request.GET.keys():
+       if x.startswith("subset"):
+            subsets[x] = request.GET[x]
+    assert(service.lower() == "wcs" and req_type.lower() == "getcoverage")
+
+    response = """
+    Service: {s} <br>
+    Version: {v} <br>
+    Request: {r} <br>
+    Layer IDs: {i} <br>
+    Subsets: {sub}
+    """.format(s=service, v=version, r=req_type, i=id_list, sub=subsets)
+
+    return HttpResponse(response)
+


### PR DESCRIPTION
Exception is raised if keys are no good. No we need to parse the subsetting
requests.